### PR TITLE
对onedrive的访问移动到后端

### DIFF
--- a/pages/article/[id].vue
+++ b/pages/article/[id].vue
@@ -109,7 +109,7 @@ export default {
                 if (!response.data.password) {
                     noNeedPassword()
                     getSettings(response.data.settings)
-                    if (response.data.contentUrl === '') {
+                    if (response.data.content === '') {
                         getContent('文件缺失，请等待同步')
                         stopLoading(1)
                         return

--- a/pages/article/[id].vue
+++ b/pages/article/[id].vue
@@ -114,17 +114,9 @@ export default {
                         stopLoading(1)
                         return
                     }
-                    axios.get(response.data.contentUrl)
-                    .then((contentResponse) => {
-                        getContent(contentResponse.data)
-                        getContentType(response.data.contentType)
-                    })
-                    .catch((contentError) => {
-                        getStatusCode(contentError.response.status)
-                    })
-                    .finally(() => {
-                        stopLoading(1)
-                    })
+                    getContent(response.data.content)
+                    getContentType(response.data.contentType)
+                    stopLoading(1)
                 } else {
                     stopLoading(1)
                     needPassword()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -80,16 +80,8 @@ export default {
         axios.get('/api/index')
         .then(async (response) => {
             if (!isBlogSettings()) {
-                await axios.get(response.data.settingsUrl)
-                .then((response) => {
-                    getSettings(response.data)
-                })
-                .catch((error) => {
-                    getStatusCode(error.response.status)
-                })
-                .finally(() => {
-                    stopLoading(1)
-                })
+                getSettings(response.data.settings)
+                stopLoading(1)
             } else {
                 stopLoading(1)
             }

--- a/server/api/article.ts
+++ b/server/api/article.ts
@@ -80,6 +80,11 @@ export default async (req: IncomingMessage, res: ServerResponse) => {
         const temp = itemsCache.find(item => item.name === fi)
         if (temp !== undefined) {
             result.contentUrl = temp['@microsoft.graph.downloadUrl']
+            axios.get(result.contentUrl)
+                    .then((contentResponse) => {
+                        result.content = contentResponse.data
+                    })
+            result.contentUrl = ‘’
             result.contentType = fi.split('.')[1]
             return result
         }

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -6,7 +6,7 @@ import { IncomingMessage, ServerResponse } from 'http'
 export default async (_req: IncomingMessage, res: ServerResponse) => {
     const result = {
         article: [],
-        settingsUrl: ''
+        settings: null
     }
 
     const accessToken = await getAccessToken(false)
@@ -33,7 +33,11 @@ export default async (_req: IncomingMessage, res: ServerResponse) => {
 
     for (const articleCacheElement of articleCache) {
         if (articleCacheElement.name === 'settings.json' || articleCacheElement.name === 'Settings.json') {
-            result.settingsUrl = articleCacheElement['@microsoft.graph.downloadUrl']
+            var settingsUrl = articleCacheElement['@microsoft.graph.downloadUrl']
+            await axios.get(settingsUrl)
+                .then((response) => {
+                    result.settings = response.data
+                })
             continue
         }
         result.article.push({


### PR DESCRIPTION
把原本在前端的从onedrive下载网页、获取设置文件的操作移动到后端进行。隐藏用于部署博客的Onedrive地址。